### PR TITLE
Fix escaping of cluster module input variables

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -30,7 +30,7 @@ local input_vars = {
 // This bit of code requires that the input variables are named identically
 // to the cluster module input variables.
 local provider_module_vars = {
-  [var]: '\\${var.%s}' % var
+  [var]: '${var.%s}' % var
   for var in std.objectFields(input_vars[params.provider])
 };
 

--- a/docs/modules/ROOT/pages/how-tos/use-exoscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-exoscale.adoc
@@ -28,7 +28,7 @@ openshift4_terraform:
       -----BEGIN CERTIFICATE-----
       ...
     ssh_key: ssh-ed25519 AA...
-    bootstrap_bucket: https://sos-${cloud:region}.exo.io/${cluster:name}-bootstrap
+    bootstrap_bucket: https://sos-${facts:region}.exo.io/${cluster:name}-bootstrap
 
     # Optional parameters:
     worker_count: 3

--- a/tests/exoscale.yaml
+++ b/tests/exoscale.yaml
@@ -7,9 +7,9 @@ parameters:
     terraform_variables:
       source: github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}?ref=${openshift4_terraform:version}
       cluster_id: ${cluster:name}
-      region: ${cloud:region}
+      region: ${facts:region}
       base_domain: exoscale.ch
       ignition_ca: SomeCertificateString
       rhcos_template: my-iso-image
       ssh_key: ssh-ed25519 AA...
-      bootstrap_bucket: https://sos-${cloud:region}.exo.io/${cluster:name}-bootstrap
+      bootstrap_bucket: https://sos-${facts:region}.exo.io/${cluster:name}-bootstrap


### PR DESCRIPTION
* fixes an extra `\` that was compiled in the Ursula config that rendered the ursula credentials invalid.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
