### PR TITLE
Fix terraform module source to work for any branch name

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,6 +10,6 @@ parameters:
     provider: ${facts:cloud}
     version: master
     terraform_variables:
-      source: github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}?ref=${openshift4_terraform:version}
+      source: git::https://github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}.git//?ref=${openshift4_terraform:version}
       cluster_id: ${cluster:name}
       region: ${facts:region}

--- a/tests/cloudscale.yaml
+++ b/tests/cloudscale.yaml
@@ -5,7 +5,7 @@ parameters:
     provider: cloudscale
     version: master
     terraform_variables:
-      source: github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}?ref=${openshift4_terraform:version}
+      source: git::https://github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}//?ref=${openshift4_terraform:version}
       cluster_id: ${cluster:name}
       region: ${cloud:region}
       base_domain: cloudscale.ch

--- a/tests/cloudscale.yaml
+++ b/tests/cloudscale.yaml
@@ -1,12 +1,13 @@
 parameters:
+  # Provide fake facts for Cloudscale/RMA
+  facts:
+    cloud: cloudscale
+    region: rma
   openshift4_terraform:
     gitlab_ci:
       tags: ["mytag"]
     provider: cloudscale
     version: master
     terraform_variables:
-      source: git::https://github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}//?ref=${openshift4_terraform:version}
-      cluster_id: ${cluster:name}
-      region: ${cloud:region}
       base_domain: cloudscale.ch
       ignition_ca: SomeCertificateString

--- a/tests/exoscale.yaml
+++ b/tests/exoscale.yaml
@@ -1,13 +1,13 @@
 parameters:
+  # Provide fake facts for Exoscale/CH-DK-2
+  facts:
+    cloud: exoscale
+    region: ch-dk-2
   openshift4_terraform:
     gitlab_ci:
       tags: ["mytag"]
-    provider: exoscale
     version: master
     terraform_variables:
-      source: git::https://github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}//?ref=${openshift4_terraform:version}
-      cluster_id: ${cluster:name}
-      region: ${facts:region}
       base_domain: exoscale.ch
       ignition_ca: SomeCertificateString
       rhcos_template: my-iso-image

--- a/tests/exoscale.yaml
+++ b/tests/exoscale.yaml
@@ -5,7 +5,7 @@ parameters:
     provider: exoscale
     version: master
     terraform_variables:
-      source: github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}?ref=${openshift4_terraform:version}
+      source: git::https://github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}//?ref=${openshift4_terraform:version}
       cluster_id: ${cluster:name}
       region: ${facts:region}
       base_domain: exoscale.ch


### PR DESCRIPTION
The new form, which explicitly requests the root directory as the module doesn't confuse terraform when the module version contains a '/'.

See https://www.terraform.io/docs/language/modules/sources.html for an explanation of the module source format.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
