### PR TITLE
Replace GitLab CI lint with plain Yaml lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-exoscale: .test ## Run tests for exoscale provider
 	rm compiled/$(COMPONENT_NAME)/$(COMPONENT_NAME)/backend.tf.json # either this, or make backend configurable
 	$(TERRAFORM_CMD) gitlab-terraform init
 	$(TERRAFORM_CMD) gitlab-terraform validate
-	$(GITLABCI_LINT_CMD)
+	$(YAMLLINT_DOCKER) -f parsable -c $(YAMLLINT_CONFIG) $(YAMLLINT_ARGS) -- $(compiled_path)/gitlab-ci.yml
 
 .PHONY: clean
 clean: ## Clean the project

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -13,7 +13,7 @@ JSONNETFMT_ARGS ?= --in-place --pad-arrays
 JSONNET_IMAGE   ?= docker.io/bitnami/jsonnet:latest
 JSONNET_DOCKER  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=jsonnetfmt $(JSONNET_IMAGE)
 
-YAML_FILES      ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.yaml' -or -name '*.yml' \))
+YAML_FILES      ?= $(shell find . -type f -not \( -path './vendor/*' -or -path '*.terraform/*' \) \( -name '*.yaml' -or -name '*.yml' \))
 YAMLLINT_ARGS   ?= --no-warnings
 YAMLLINT_CONFIG ?= .yamllint.yml
 YAMLLINT_IMAGE  ?= docker.io/cytopia/yamllint:latest
@@ -28,6 +28,3 @@ COMMODORE_CMD  ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) projectsyn/commodo
 
 TERRAFORM_IMAGE ?= $(shell grep image: class/defaults.yml | sed 's/ *//g' | cut -d : -f 2):$(shell grep tag: class/defaults.yml | sed 's/ *//g' | cut -d : -f 2)
 TERRAFORM_CMD   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(compiled_volume) $(extra_args) $(TERRAFORM_IMAGE)
-
-GITLABCI_LINT_IMAGE ?= docker.io/gableroux/gitlab-ci-lint:latest
-GITLABCI_LINT_CMD ?= cat $(compiled_path)/gitlab-ci.yml | $(DOCKER_CMD) $(DOCKER_ARGS) $(compiled_volume) -i $(GITLABCI_LINT_IMAGE)


### PR DESCRIPTION
Due to a GitLab security issue, the CI lint API endpoint is behind authentication.
Let's remove the GitLab CI linting for the time being.

Might be re-added later if https://github.com/GabLeRoux/docker-gitlab-ci-lint/issues/15 is resolved.

Closes #7 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
