### PR TITLE
Fix name of GitLab CI file

### DIFF
--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -101,5 +101,5 @@ local GitLabCI() = {
 };
 
 {
-  'gitlab-ci': GitLabCI(),
+  '.gitlab-ci': GitLabCI(),
 }


### PR DESCRIPTION
Slight oversight: GitLab only picks up '.gitlab-ci.yml' (leading dot)

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
