### PR TITLE
Add support for puppet-managed LBs on cloudscale

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
           body: ${{steps.build_changelog.outputs.changelog}}
           prerelease: "${{ contains(github.ref, '-rc') }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ensure target branch for release is "master"
+          commit: master
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   openshift4_terraform:
     =_tf_module_version:
-      cloudscale: v1.0.0
+      cloudscale: v2.0.0
       exoscale: v1.0.0
     images:
       terraform:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,7 +5,6 @@ parameters:
       exoscale: v1.0.0
     images:
       terraform:
-        # Don't forget to update the image also in the documentation
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/0.14
         tag: v0.10.0
     gitlab_ci:

--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -7,6 +7,10 @@ local cloud_specific_variables = {
   cloudscale: {
     default: {
       CLOUDSCALE_TOKEN: '${CLOUDSCALE_TOKEN_RO}',
+      TF_VAR_lb_cloudscale_api_secret: '${CLOUDSCALE_FLOATY_SECRET}',
+      TF_VAR_control_vshn_net_token: '${CONTROL_VSHN_NET_TOKEN}',
+      [if std.objectHas(git, 'username') then 'GIT_AUTHOR_NAME']: git.username,
+      [if std.objectHas(git, 'email') then 'GIT_AUTHOR_EMAIL']: git.email,
     },
     apply: {
       CLOUDSCALE_TOKEN: '${CLOUDSCALE_TOKEN_RW}',

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -15,6 +15,12 @@ local input_vars = {
     ignition_bootstrap: {
       default: '',
     },
+    lb_cloudscale_api_secret: {
+      default: '',
+    },
+    control_vshn_net_token: {
+      default: '',
+    },
   },
   exoscale: {
     lb_exoscale_api_key: {
@@ -32,12 +38,11 @@ local input_vars = {
 // Configure Terraform outputs
 local common_outputs = {
   cluster_dns: cluster_dns[params.provider],
+  hieradata_mr: '${module.cluster.hieradata_mr}',
 };
 local outputs = {
   cloudscale: common_outputs,
-  exoscale: common_outputs {
-    hieradata_mr: '${module.cluster.hieradata_mr}',
-  },
+  exoscale: common_outputs,
 };
 
 // We want to pass through any provider-specific input variables (see above)

--- a/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v1-v2.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v1-v2.adoc
@@ -1,4 +1,4 @@
-= Upgrade Cloudscale.ch Terraform module from v1 to v2
+= Upgrade cloudscale.ch Terraform module from v1 to v2
 
 https://github.com/appuio/terraform-openshift4-cloudscale/releases/tag/v2.0.0[terraform-openshift4-cloudscale v2.0.0] introduces Puppet-managed load balancer VMs managed by VSHN.
 

--- a/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v1-v2.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v1-v2.adoc
@@ -1,0 +1,89 @@
+= Upgrade Cloudscale.ch Terraform module from v1 to v2
+
+https://github.com/appuio/terraform-openshift4-cloudscale/releases/tag/v2.0.0[terraform-openshift4-cloudscale v2.0.0] introduces Puppet-managed load balancer VMs managed by VSHN.
+
+That release includes breaking changes which require manual steps to upgrade existing clusters.
+
+== Prerequisites
+
+* `ssh-keygen`
+* `jq`
+* `vault` https://www.vaultproject.io/docs/commands[Vault CLI]
+* `base64`
+* `curl`
+
+== Setup environment variables
+
+.Access to API
+[source,bash]
+----
+# For example: https://api.syn.vshn.net
+# IMPORTANT: do NOT add a trailing `/`. Commands below will fail.
+export COMMODORE_API_URL=<lieutenant-api-endpoint>
+export COMMODORE_API_TOKEN=<lieutenant-api-token>
+
+export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-<something>
+export TENANT_ID=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
+----
+
+== Update credentials
+
+. Add an additional cloudscale.ch token for Floaty and configure GitLab repository as described in xref:how-tos/use-cloudscale.adoc[Use cloudscale.ch]
+
+. Connect with Vault
++
+[source,bash]
+----
+export VAULT_ADDR=https://vault-prod.syn.vshn.net
+vault login -method=ldap username=<your.name>
+----
+
+. Prepare SSH key
++
+[NOTE]
+====
+We generate a unique SSH key pair for the cluster for troubleshooting access to the cluster hosts.
+====
++
+[source,bash]
+----
+SSH_PRIVATE_KEY="$(pwd)/ssh_$CLUSTER_ID"
+export SSH_PUBLIC_KEY="${SSH_PRIVATE_KEY}.pub"
+
+ssh-keygen -C "vault@$CLUSTER_ID" -t ed25519 -f $SSH_PRIVATE_KEY -N ''
+
+vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cloudscale/ssh \
+  private_key=$(cat $SSH_PRIVATE_KEY | base64 --wrap 0)
+----
+
+== Update component parameters
+
+. Set the `ssh_keys` parameter
++
+[source,yaml]
+----
+openshift4_terraform:
+  provider: cloudscale
+  terraform_variables:
+    ssh_keys:
+      - ssh-ed25519 AA... <1>
+----
+<1> The SSH public key in `$SSH_PUBLIC_KEY`.
+
+. Set the Git author _(Optional)_
++
+[source,yaml]
+----
+openshift4_terraform:
+  provider: cloudscale
+  gitlab_ci:
+    git: <1>
+      username: Max Mustermann
+      email: mm@example.com
+----
+<1> The Git author name and email address.
+Used when creating hieradata commits.
+If not specified, the GitLab CI defaults will be used.
+
+. Commit and push the changes
+. Compile the cluster catalog

--- a/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
@@ -1,30 +1,62 @@
 = Use Cloudscale.ch
 
-The following steps show how to set up Terraform with cloudscale.ch.
+IMPORTANT: Currently the Terraform module which this component uses for Cloudscale only supports provisioning VSHN-managed OCP4 clusters on cloudscale.ch.
 
-. Set up 2 new API keys in https://control.cloudscale.ch[control.cloudscale.ch].
-  One is for read-only access, the other for mutating operations.
+NOTE: See https://kb.vshn.ch/oc4/how-tos/cloudscale/install.html[the cloudscale.ch installation how-to] for a comprehensive how-to for setting up OCP4 on cloudscale.ch.
+
+The following steps show how to set up Terraform with cloudscale.ch
+
+NOTE: The component currently assumes that the Git repositories live on a GitLab instance.
+
+== Setup credentials
+
+. Set up 3 new API keys in https://control.cloudscale.ch[control.cloudscale.ch].
+  Two of them are used for the Terraform pipeline.
+.. The first key should be created with read-only permissions and will be used for read-only GitLab CI jobs.
+.. The second key can be created with read/write permissions and will be used for mutating GitLab CI jobs but also for the initial cluster installation.
+.. The third key needs read/write permissions and will be deployed onto the LBs for https://github.com/vshn/floaty[Floaty]):
+
+include::partial$puppet-lb-cred.adoc[]
+
+== Setup component
+
 . Configure component parameters.
 +
 [source,yaml]
 ----
 openshift4_terraform:
   provider: cloudscale
+  gitlab_ci:
+    git: <1>
+      username: Max Mustermann
+      email: mm@example.com
   terraform_variables:
     # Required parameters
     base_domain: ${openshift:baseDomain}
     ignition_ca: |-
       -----BEGIN CERTIFICATE-----
       ...
+    ssh_keys:
+      - ssh-ed25519 AA...
+    hieradata_repo_user: project_123_bot <2>
 
     # Optional parameters:
     worker_count: 3
     infra_flavor: plus-24
 ----
+<1> The Git author name and email address.
+Used when creating hieradata commits.
+If not specified, the GitLab CI defaults will be used.
+<2> The user created for the hieradata project access token.
+Please note that the Terraform module currently only supports the https://git.vshn.net/appuio/appuio_hieradata[VSHN APPUiO hieradata]
 
 . Compile the cluster catalog
 . Configure GitLab repository
-  - *CI/CD*: Configuration file: `manifests/openshift4-terraform/gitlab-ci.yml`
-  - *CI/CD*: Variables:
+  - "Settings > CI/CD > General pipelines > Configuration file" +
+    `manifests/openshift4-terraform/gitlab-ci.yml`
+  - "Settings > CI/CD > Variables"
     * `CLOUDSCALE_TOKEN_RO`
     * `CLOUDSCALE_TOKEN_RW`
+    * `CLOUDSCALE_FLOATY_SECRET`
+    * `HIERADATA_REPO_TOKEN` -- the VSHN APPUiO hieradata project access token
+    * `CONTROL_VSHN_NET_TOKEN`

--- a/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
@@ -1,6 +1,6 @@
 = Use Cloudscale.ch
 
-IMPORTANT: Currently the Terraform module which this component uses for Cloudscale only supports provisioning VSHN-managed OCP4 clusters on cloudscale.ch.
+IMPORTANT: Currently the Terraform module which this component uses for cloudscale.ch only supports provisioning VSHN-managed OCP4 clusters.
 
 NOTE: See https://kb.vshn.ch/oc4/how-tos/cloudscale/install.html[the cloudscale.ch installation how-to] for a comprehensive how-to for setting up OCP4 on cloudscale.ch.
 

--- a/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
@@ -1,4 +1,4 @@
-= Use Cloudscale.ch
+= Use cloudscale.ch
 
 IMPORTANT: Currently the Terraform module which this component uses for cloudscale.ch only supports provisioning VSHN-managed OCP4 clusters.
 

--- a/docs/modules/ROOT/pages/how-tos/use-exoscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-exoscale.adoc
@@ -34,20 +34,7 @@ Two of them are used for the Terraform pipeline.
   * `queryAsyncJobResult`
   * `removeIpFromNic`
 
-. Create a "Project Access Token" for the hieradata repository.
-  The token requires the following permissions:
-  - `api`
-  - `read_repository`
-  - `write_repository`
-
-+
-The user which is created will be named `project_<project-id>_bot`, where `<project-id>` is the project ID of the GitLab project.
-If the project already has access tokens the user will be named `project_<project-id>_bot<N>` instead, where `N` is a running counter (`1` for the second token, etc.)
-
-. Set up a "Servers API" token on https://control.vshn.net/tokens/_create/servers[control.vshn.net].
-
-. If there's no access token configured on the https://git.vshn.net/appuio/appuio_hieradata/-/settings/access_tokens[APPUiO hieradata repo], create one.
-Otherwise check https://vault-prod.syn.vshn.net/ui/vault/secrets/clusters%2Fkv/show/lbaas/hieradata_repo_token[Vault] for the token.
+include::partial$puppet-lb-cred.adoc[]
 
 == Setup component
 
@@ -94,4 +81,4 @@ Please note that the Terraform module currently only supports the https://git.vs
     * `EXOSCALE_FLOATY_KEY`
     * `EXOSCALE_FLOATY_SECRET`
     * `HIERADATA_REPO_TOKEN` -- the VSHN APPUiO hieradata project access token
-    * `CONTROL_VSHN_NET_TOKEN` --
+    * `CONTROL_VSHN_NET_TOKEN`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -62,5 +62,5 @@ The git revision of the selected Terraform module (see parameter `provider`)
 
 See examples in the how-to pages:
 
-* xref:how-tos/use-cloudscale.adoc[Cloudscale.ch example]
+* xref:how-tos/use-cloudscale.adoc[cloudscale.ch example]
 * xref:how-tos/use-exoscale.adoc[Exoscale example]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -28,7 +28,7 @@ The GitLab CI Runner tags to apply to the GitLab jobs.
 
 [horizontal]
 type:: string
-default:: `registry.gitlab.com/gitlab-org/terraform-images/releases/0.14`
+default:: see `class/defaults.yml`, key `openshift4_terraform.images.terraform`
 
 This is the image repository that's used in the generated GitLab CI configuration for automated pipelines.
 

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -3,6 +3,7 @@
 .How-to guides
 * xref:how-tos/use-cloudscale.adoc[Use Cloudscale.ch]
 * xref:how-tos/use-exoscale.adoc[Use Exoscale]
+* xref:how-tos/upgrade-cloudscale-v1-v2.adoc[Upgrade Cloudscale.ch from v1 to v2]
 
 .Technical reference
 * xref:references/parameters.adoc[Parameters]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,9 +1,9 @@
 * xref:index.adoc[Home]
 
 .How-to guides
-* xref:how-tos/use-cloudscale.adoc[Use Cloudscale.ch]
+* xref:how-tos/use-cloudscale.adoc[Use cloudscale.ch]
 * xref:how-tos/use-exoscale.adoc[Use Exoscale]
-* xref:how-tos/upgrade-cloudscale-v1-v2.adoc[Upgrade Cloudscale.ch from v1 to v2]
+* xref:how-tos/upgrade-cloudscale-v1-v2.adoc[Upgrade cloudscale.ch from v1 to v2]
 
 .Technical reference
 * xref:references/parameters.adoc[Parameters]

--- a/docs/modules/ROOT/partials/puppet-lb-cred.adoc
+++ b/docs/modules/ROOT/partials/puppet-lb-cred.adoc
@@ -1,0 +1,15 @@
+
+. Create a "Project Access Token" for the hieradata repository.
+  The token requires the following permissions:
+  - `api`
+  - `read_repository`
+  - `write_repository`
+
++
+The user which is created will be named `project_<project-id>_bot`, where `<project-id>` is the project ID of the GitLab project.
+If the project already has access tokens the user will be named `project_<project-id>_bot<N>` instead, where `N` is a running counter (`1` for the second token, etc.)
+
+. Set up a "Servers API" token on https://control.vshn.net/tokens/_create/servers[control.vshn.net].
+
+. If there's no access token configured on the https://git.vshn.net/appuio/appuio_hieradata/-/settings/access_tokens[APPUiO hieradata repo], create one.
+Otherwise check https://vault-prod.syn.vshn.net/ui/vault/secrets/clusters%2Fkv/show/lbaas/hieradata_repo_token[Vault] for the token.

--- a/tests/cloudscale.yaml
+++ b/tests/cloudscale.yaml
@@ -10,3 +10,7 @@ parameters:
     terraform_variables:
       base_domain: cloudscale.ch
       ignition_ca: SomeCertificateString
+      ssh_keys:
+        - ssh-ed25519 AA...
+      control_vshn_net_token: asdf...
+      hieradata_repo_user: project_123_bot


### PR DESCRIPTION
* Updates the component and docs to use with puppet-managed load balancers.
* Aligns Exoscale and Cloudscale how-to pages, uses a partial

Related:
* https://github.com/appuio/openshift4-docs/pull/96/
* https://github.com/appuio/terraform-openshift4-cloudscale/pull/19

Labelled `Breaking` since now an `terraform_variables.ssh_keys` is necessary for cloudscale provider.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
