### PR TITLE
Pin default version to v1.0.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,5 +1,8 @@
 parameters:
   openshift4_terraform:
+    =_tf_module_version:
+      cloudscale: v1.0.0
+      exoscale: v1.0.0
     images:
       terraform:
         # Don't forget to update the image also in the documentation
@@ -9,7 +12,7 @@ parameters:
       tags: []
       git: {}
     provider: ${facts:cloud}
-    version: master
+    version: ${openshift4_terraform:_tf_module_version:${openshift4_terraform:provider}}
     terraform_variables:
       source: git::https://github.com/appuio/terraform-openshift4-${openshift4_terraform:provider}.git//?ref=${openshift4_terraform:version}
       cluster_id: ${cluster:name}

--- a/tests/cloudscale.yaml
+++ b/tests/cloudscale.yaml
@@ -7,7 +7,6 @@ parameters:
     gitlab_ci:
       tags: ["mytag"]
     provider: cloudscale
-    version: master
     terraform_variables:
       base_domain: cloudscale.ch
       ignition_ca: SomeCertificateString

--- a/tests/exoscale.yaml
+++ b/tests/exoscale.yaml
@@ -6,7 +6,6 @@ parameters:
   openshift4_terraform:
     gitlab_ci:
       tags: ["mytag"]
-    version: master
     terraform_variables:
       base_domain: exoscale.ch
       ignition_ca: SomeCertificateString


### PR DESCRIPTION
Both exoscale and cloudscale module versions have a v1
This is to prepare the component for another v1.1 release that has a default version parameter to something that is considered current "master" branch before introducing breaking changes.

After such release, the `version` can be bumped to v2.0.0 for the cloudscale provider.

Should be merged before #12 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
