### PR TITLE
Fix apply job to be able to use Git and curl

### DIFF
--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -96,6 +96,8 @@ local GitLabCI() = {
     },
     variables: cloud_specific_variables[params.provider].apply,
     script: [
+      'apk add --no-cache curl',
+      'export GIT_ASKPASS=${TF_ROOT}/git-askpass.sh',
       'gitlab-terraform apply',
     ],
     dependencies: [


### PR DESCRIPTION
Install `curl` in the apply job and set `GIT_ASKPASS` to the `git-askpass.sh` script managed by the component.

We export `GIT_ASKPASS` explicitly in the job steps instead of setting it in the `environment` section, because otherwise the nested environment variable references are not fully resolved leading to errors like

```
fatal: cannot run ${CI_PROJECT_DIR}/manifests/openshift4-terraform/git-askpass.sh: No such file or directory
fatal: could not read Password for 'https://project_368_bot@git.vshn.net': No such device or address
```
## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
