### PR TITLE
Update cloudscale.ch terraform module to `v3.1.1`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   openshift4_terraform:
     =_tf_module_version:
-      cloudscale: v3.0.0
+      cloudscale: v3.1.1
       exoscale: v1.2.0
     images:
       terraform:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   openshift4_terraform:
     =_tf_module_version:
-      cloudscale: v2.1.2
+      cloudscale: v3.0.0
       exoscale: v1.2.0
     images:
       terraform:

--- a/class/openshift4-terraform.yml
+++ b/class/openshift4-terraform.yml
@@ -16,5 +16,6 @@ parameters:
           - openshift4-terraform/scripts/terraform.sh
           - openshift4-terraform/scripts/tf.sh
           - openshift4-terraform/scripts/git-askpass.sh
+          - openshift4-terraform/scripts/migrate-state-v2-v3.sh
         input_type: copy
         output_path: openshift4-terraform/

--- a/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v1-v2.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v1-v2.adoc
@@ -94,7 +94,7 @@ yq eval -i '.parameters.openshift4_terraform.gitlab_ci.git = {
 ----
 <1> The Git author name to use when creating hieradata commits from GitLab CI.
 If not specified, the GitLab CI defaults will be used.
-<1> The Git author email address to use when creating hieradata commits from GitLab CI.
+<2> The Git author email address to use when creating hieradata commits from GitLab CI.
 If not specified, the GitLab CI defaults will be used.
 
 . Commit and push the changes in the tenant repo

--- a/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v2-v3.adoc
@@ -1,0 +1,125 @@
+= Upgrade cloudscale.ch Terraform module from v2 to v3
+
+https://github.com/appuio/terraform-openshift4-cloudscale/releases/tag/v3.0.0[terraform-openshift4-cloudscale v3.0.0] moves load balancer state to a shared module.
+
+That release includes breaking changes which require manual steps to upgrade existing clusters.
+
+== Prerequisites
+
+You need to be able to execute the following CLI tools locally:
+
+* `docker`
+* `yq` https://github.com/mikefarah/yq[yq YAML processor] (Version 4 or newer)
+* `jq`
+* `vault` https://www.vaultproject.io/docs/commands[Vault CLI]
+
+== Setup environment
+
+. Access to API
++
+[source,bash]
+----
+# For example: https://api.syn.vshn.net
+# IMPORTANT: do NOT add a trailing `/`. Commands below will fail.
+export COMMODORE_API_URL=<lieutenant-api-endpoint>
+export COMMODORE_API_TOKEN=<lieutenant-api-token>
+
+export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-<something>
+export TENANT_ID=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
+
+# From https://git.vshn.net/-/profile/personal_access_tokens, "api" scope is sufficient
+export GITLAB_TOKEN=<gitlab-api-token>
+export GITLAB_USER=<gitlab-user-name>
+----
+
+. Connect with Vault
++
+[source,bash]
+----
+export VAULT_ADDR=https://vault-prod.syn.vshn.net
+vault login -method=ldap username=<your.name>
+----
+
+. Compile the cluster catalog to create a local working directory
++
+[source,bash]
+----
+commodore catalog compile "${CLUSTER_ID}"
+----
+
+== Migrate Terraform state
+
+. Configure Terraform secrets
++
+[source,bash]
+----
+export CLOUDSCALE_TOKEN=$(vault kv get -format=json \
+  clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cloudscale \
+  | jq -r '.data.data.token')
+
+cat <<EOF > ./terraform.env
+CLOUDSCALE_TOKEN
+EOF
+----
+
+. Setup Terraform
++
+.Prepare Terraform execution environment
+[source,bash]
+----
+# Set terraform image and tag to be used
+tf_image=$(\
+  yq eval ".parameters.openshift4_terraform.images.terraform.image" \
+  dependencies/openshift4-terraform/class/defaults.yml)
+tf_tag=$(\
+  yq eval ".parameters.openshift4_terraform.images.terraform.tag" \
+  dependencies/openshift4-terraform/class/defaults.yml)
+
+# Generate the terraform alias
+base_dir=$(pwd)
+alias terraform='docker run -it --rm \
+  -e REAL_UID=$(id -u) \
+  --env-file ${base_dir}/terraform.env \
+  -w /tf \
+  -v $(pwd):/tf \
+  --ulimit memlock=-1 \
+  "${tf_image}:${tf_tag}" /tf/terraform.sh'
+
+export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||; s|/|:|')
+export GITLAB_REPOSITORY_NAME=${GITLAB_REPOSITORY_URL##*/}
+export GITLAB_CATALOG_PROJECT_ID=$(curl -sH "Authorization: Bearer ${GITLAB_TOKEN}" "https://git.vshn.net/api/v4/projects?simple=true&search=${GITLAB_REPOSITORY_NAME/.git}" | jq -r ".[] | select(.ssh_url_to_repo == \"${GITLAB_REPOSITORY_URL}\") | .id")
+export GITLAB_STATE_URL="https://git.vshn.net/api/v4/projects/${GITLAB_CATALOG_PROJECT_ID}/terraform/state/cluster"
+
+pushd catalog/manifests/openshift4-terraform/
+----
++
+.Initialize Terraform
+[source,bash]
+----
+terraform init \
+  "-backend-config=address=${GITLAB_STATE_URL}" \
+  "-backend-config=lock_address=${GITLAB_STATE_URL}/lock" \
+  "-backend-config=unlock_address=${GITLAB_STATE_URL}/lock" \
+  "-backend-config=username=${GITLAB_USER}" \
+  "-backend-config=password=${GITLAB_TOKEN}" \
+  "-backend-config=lock_method=POST" \
+  "-backend-config=unlock_method=DELETE" \
+  "-backend-config=retry_wait_min=5"
+----
+
+. Migrate state
++
+.Run the migration script
+[source,bash]
+----
+./migrate-state-v2-v3.sh
+----
++
+.Verify state using `plan`
+[source,bash]
+----
+# No resources, except the hieradata git checkout, should be recreated.
+terraform plan
+----
+
+NOTE: Terraform may wants to create the hieradata git checkout. This is expected and can be ignored.

--- a/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v2-v3.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-cloudscale-v2-v3.adoc
@@ -1,8 +1,10 @@
 = Upgrade cloudscale.ch Terraform module from v2 to v3
 
-https://github.com/appuio/terraform-openshift4-cloudscale/releases/tag/v3.0.0[terraform-openshift4-cloudscale v3.0.0] moves load balancer state to a shared module.
+When migrating from v2 to v3, the following breaking changes require manual changes to the Terraform state of existing clusters:
 
-That release includes breaking changes which require manual steps to upgrade existing clusters.
+* https://github.com/appuio/terraform-openshift4-cloudscale/releases/tag/v3.0.0[terraform-openshift4-cloudscale v3.0.0] uses the new https://github.com/appuio/terraform-modules/tree/main/modules/vshn-lbaas-cloudscale[shared load-balancer module] to provision the LBs.
+* https://github.com/appuio/terraform-openshift4-cloudscale/releases/tag/v3.1.0[terraform-openshift4-cloudscale v3.1.0] adds support for using an existing cloudscale.ch subnet.
+
 
 == Prerequisites
 
@@ -122,4 +124,4 @@ terraform init \
 terraform plan
 ----
 
-NOTE: Terraform may wants to create the hieradata git checkout. This is expected and can be ignored.
+NOTE: Terraform may want to create the hieradata git checkout. This is expected and can be ignored.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -4,6 +4,7 @@
 * xref:how-tos/use-cloudscale.adoc[Use cloudscale.ch]
 * xref:how-tos/use-exoscale.adoc[Use Exoscale]
 * xref:how-tos/upgrade-cloudscale-v1-v2.adoc[Upgrade cloudscale.ch from v1 to v2]
+* xref:how-tos/upgrade-cloudscale-v2-v3.adoc[Upgrade cloudscale.ch from v2 to v3]
 * xref:how-tos/migrate-from-openshift4-cloudscale.adoc[Migrate from component `openshift4-cloudscale`]
 
 .Technical reference

--- a/scripts/migrate-state-v2-v3.sh
+++ b/scripts/migrate-state-v2-v3.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+terraform state mv module.cluster.cloudscale_floating_ip.api_vip module.cluster.module.lb.cloudscale_floating_ip.api_vip
+terraform state mv module.cluster.cloudscale_floating_ip.router_vip module.cluster.module.lb.cloudscale_floating_ip.router_vip
+terraform state mv module.cluster.cloudscale_floating_ip.nat_vip module.cluster.module.lb.cloudscale_floating_ip.nat_vip
+
+terraform state mv module.cluster.cloudscale_server.lb module.cluster.module.lb.cloudscale_server.lb
+terraform state mv module.cluster.cloudscale_server_group.lb module.cluster.module.lb.cloudscale_server_group.lb
+terraform state mv module.cluster.random_id.lb module.cluster.module.lb.random_id.lb
+terraform state mv module.cluster.null_resource.register_lb module.cluster.module.lb.null_resource.register_lb
+
+terraform state mv module.cluster.data.local_file.hieradata_mr_url 'module.cluster.module.lb.module.hiera.data.local_file.hieradata_mr_url[0]'
+terraform state mv 'module.cluster.gitfile_checkout.appuio_hieradata[0]' module.cluster.module.lb.module.hiera.gitfile_checkout.appuio_hieradata
+terraform state mv 'module.cluster.local_file.lb_hieradata[0]' module.cluster.module.lb.module.hiera.local_file.lb_hieradata

--- a/scripts/migrate-state-v2-v3.sh
+++ b/scripts/migrate-state-v2-v3.sh
@@ -13,3 +13,6 @@ terraform state mv module.cluster.null_resource.register_lb module.cluster.modul
 terraform state mv module.cluster.data.local_file.hieradata_mr_url 'module.cluster.module.lb.module.hiera.data.local_file.hieradata_mr_url[0]'
 terraform state mv 'module.cluster.gitfile_checkout.appuio_hieradata[0]' module.cluster.module.lb.module.hiera.gitfile_checkout.appuio_hieradata
 terraform state mv 'module.cluster.local_file.lb_hieradata[0]' module.cluster.module.lb.module.hiera.local_file.lb_hieradata
+
+terraform state mv module.cluster.cloudscale_network.privnet 'module.cluster.cloudscale_network.privnet[0]'
+terraform state mv module.cluster.cloudscale_subnet.privnet_subnet 'module.cluster.cloudscale_subnet.privnet_subnet[0]'


### PR DESCRIPTION
Two breaking changes:
- https://github.com/appuio/terraform-openshift4-cloudscale/pull/33
- https://github.com/appuio/terraform-openshift4-cloudscale/pull/29

This PR updates the module and includes a how-to for the required Terraform state migration.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
