### PR TITLE
Bump terraform-openshift4-exoscale to v2.3.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   openshift4_terraform:
     =_tf_module_version:
       cloudscale: v3.9.0
-      exoscale: v2.2.0
+      exoscale: v2.3.0
     images:
       terraform:
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/0.14


### PR DESCRIPTION
The new module version configures the security group rules required for Cilium on Exoscale.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
