### PR TITLE
Update terraform-openshif4-cloudscale to v3.10.0, introducing datasources for existing subnets

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   openshift4_terraform:
     =_tf_module_version:
-      cloudscale: v3.9.1
+      cloudscale: v3.10.0
       exoscale: v2.3.1
     images:
       terraform:


### PR DESCRIPTION
With this update we use datasources for subnets. This allows us to deploy a cluster into an existing subnet by providing the subnet's uuid. In earlier versions of this component we had to specify matching privnet uuid, subnet uuid, and CIDR when wanting to deploy a cluster into an existing cloudscale.ch private network.

The variable `privnet_uuid` is no longer used and `privnet_cidr` will be ignored if a subnet uuid is provided


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
