### PR TITLE
Bump Terraform to 1.3.1

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,12 +1,12 @@
 parameters:
   openshift4_terraform:
     =_tf_module_version:
-      cloudscale: v3.13.1
-      exoscale: v2.4.0
+      cloudscale: v4.0.0
+      exoscale: v3.0.0-beta.1
     images:
       terraform:
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/terraform
-        tag: '1.2.9'
+        tag: '1.3.1'
     gitlab_ci:
       tags: []
       git: {}


### PR DESCRIPTION
With Terraform >= 1.3.0, we need module version >= v4.0.0 for cloudscale.ch and module version >= v3.0.0 for Exoscale. The
v3.0.0-beta.1 release of the Exoscale module includes the required updates for Terraform >= 1.3.0, but there's more breaking changes coming, and we will update the Exoscale module to the final v3.0.0 in https://github.com/appuio/component-openshift4-terraform/pull/61.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
