### PR TITLE
Make unsupported Terraform module versions a compilation error

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -9,6 +9,49 @@ local cluster_dns = {
   exoscale: '${module.cluster.ns_records}',
 };
 
+// Cutoff major versions for Terraform older than 1.3.0
+// With Terraform < 1.3.0, we only support major module versions < the values
+// here, while with Terraform >= 1.3.0 we only support major module versions
+// >= the values here.
+local module_cutoff_major_versions = {
+  cloudscale: 4,
+  exoscale: 3,
+};
+
+// This evaluates to a boolean indicating whether the configured Terraform
+// version is >= 1.3.0.
+local tf_1_3 =
+  local terraformVersion = std.split(params.images.terraform.tag, '.');
+  if std.length(terraformVersion) < 3 then
+    error 'Unable to parse Terraform image tag'
+  else
+    local parsedTfVersion = std.map(std.parseInt, terraformVersion);
+    if parsedTfVersion[0] > 1 then
+      error "Component doesn't support Terraform 2.x"
+    else
+      if parsedTfVersion[0] == 1 && parsedTfVersion[1] >= 3 then
+        true
+      else
+        false;
+
+// This evaluates to a boolean indicating whether the configured combination
+// of Terraform version, module version, and cloud provider is supported.
+local supported_module_version =
+  local verParts = std.split(params.version, '.');
+  if std.length(verParts) < 3 then
+    // probably not a version, just say it's supported
+    true
+  else
+    local paramsMajor = std.parseInt(std.lstripChars(verParts[0], 'v'));
+    if tf_1_3 then
+      // for Terraform >= 1.3.0 we need at least the cutoff module major
+      // version
+      paramsMajor >= module_cutoff_major_versions[params.provider]
+    else
+      // for Terraform < 1.3.0 we need a module major version < the cutoff
+      // version
+      paramsMajor < module_cutoff_major_versions[params.provider];
+
 // Configure Terraform input variables which are provided at runtime
 local input_vars = {
   cloudscale: {
@@ -90,5 +133,20 @@ local terraform_config =
 if std.member(std.objectFields(cluster_dns), params.provider) == false then
   error 'openshift4_terraform.provider "' + params.provider + '" is not supported by this component. Currently supported are ' + std.objectFields(cluster_dns) + '. If you think this is a bug in the component, file an issue on https://github.com/appuio/component-openshift4-terraform.'
 else
-  // output
-  terraform_config
+  if !supported_module_version then
+    // Generate a compilation error if the combination of Terraform version,
+    // module version and cloud provider is not supported.
+    local verLimit =
+      if tf_1_3 then
+        module_cutoff_major_versions[params.provider]
+      else
+        module_cutoff_major_versions[params.provider] - 1;
+    error 'The %s supported Terraform module version for provider "%s" is `v%d.0.0` for Terraform version `%s`' % [
+      if tf_1_3 then 'minimum' else 'maximum',
+      params.provider,
+      verLimit,
+      params.images.terraform.tag,
+    ]
+  else
+    // output
+    terraform_config

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,4 +2,16 @@
 
 openshift4-terraform is a Commodore component to manage openshift4-terraform.
 
+The component currently supports cloud providers https://www.cloudscale.ch[cloudscale.ch] and https://www.exoscale.com[Exoscale].
+
+The component allows users to drive the `terraform-openshift4-cloudscale` and `terraform-openshift4-exoscale` Terraform modules through the Project Syn hierarchy.
+
+The component contains logic which verifies the provided combination of Terraform version, Terraform module version and cloud provider.
+Configurations which result an unsupported combination will cause a compilation error.
+
+The component currently supports
+
+* Terraform{nbsp}<{nbsp}1.3.0 with module versions{nbsp}<{nbsp}v4.0.0 for cloudscale.ch or module versions{nbsp}<{nbsp}v3.0.0 for Exoscale or
+* Terraform{nbsp}>={nbsp}1.3.0 with module versions{nbsp}>={nbsp}v4.0.0 for cloudscale.ch or module versions{nbsp}>={nbsp}v3.0.0 for Exoscale
+
 See the xref:references/parameters.adoc[parameters] reference for further details.


### PR DESCRIPTION
Factored out from #61. After upgrading the component to use Terraform 1.3.1 by default, we can't support Terraform module versions which aren't compatible with Terraform 1.3.0 and newer anymore.

This PR adds a check which results in a compilation error if users either specify older module versions <= v4.0.0 for cloudscale.ch and <= v3.0.0 for Exoscale with a Terraform version >= 1.3.0 or module versions >= v4.0.0 / v3.0.0 with Terraform < 1.3.0. Module versions which aren't recognized as SemVer tags (prefixed with a `v`) never result in a compilation error.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
