### PR TITLE
Bump default Exoscale terraform module version to v3.2.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,7 +2,7 @@ parameters:
   openshift4_terraform:
     =_tf_module_version:
       cloudscale: v4.0.0
-      exoscale: v3.1.0
+      exoscale: v3.2.0
     images:
       terraform:
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/terraform

--- a/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/main.tf.json
+++ b/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/main.tf.json
@@ -9,7 +9,7 @@
       "ignition_ca": "SomeCertificateString",
       "region": "ch-dk-2",
       "rhcos_template": "my-iso-image",
-      "source": "git::https://github.com/appuio/terraform-openshift4-exoscale.git//?ref=v3.1.0",
+      "source": "git::https://github.com/appuio/terraform-openshift4-exoscale.git//?ref=v3.2.0",
       "ssh_key": "ssh-ed25519 AA..."
     }
   }


### PR DESCRIPTION
This update fixes the broken initial `terraform apply` by switching the internal LB module inputs and outputs from using security group names to security group ids.

See also https://github.com/appuio/terraform-openshift4-exoscale/pull/72 and https://github.com/appuio/terraform-modules/pull/39


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
