### PR TITLE
Only generate GitLab CI config for `TF_VAR_lb_exoscale*` for Exoscale terraform module v4.x

### DIFF
--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -2,6 +2,7 @@ local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.openshift4_terraform;
 local git = params.gitlab_ci.git;
+local version = import 'version.libsonnet';
 
 local cloud_specific_variables = {
   cloudscale: {
@@ -20,12 +21,13 @@ local cloud_specific_variables = {
     default: {
       EXOSCALE_API_KEY: '${EXOSCALE_API_KEY_RO}',
       EXOSCALE_API_SECRET: '${EXOSCALE_API_SECRET_RO}',
-      TF_VAR_lb_exoscale_api_key: '${EXOSCALE_FLOATY_KEY}',
-      TF_VAR_lb_exoscale_api_secret: '${EXOSCALE_FLOATY_SECRET}',
       TF_VAR_control_vshn_net_token: '${CONTROL_VSHN_NET_TOKEN}',
       [if std.objectHas(git, 'username') then 'GIT_AUTHOR_NAME']: git.username,
       [if std.objectHas(git, 'email') then 'GIT_AUTHOR_EMAIL']: git.email,
-    },
+    } + if version.tfModuleMajorVersion > 3 && version.tfModuleMajorVersion < 5 then {
+      TF_VAR_lb_exoscale_api_key: '${EXOSCALE_FLOATY_KEY}',
+      TF_VAR_lb_exoscale_api_secret: '${EXOSCALE_FLOATY_SECRET}',
+    } else {},
     apply: {
       EXOSCALE_API_KEY: '${EXOSCALE_API_KEY_RW}',
       EXOSCALE_API_SECRET: '${EXOSCALE_API_SECRET_RW}',

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -4,57 +4,12 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_terraform;
 
+local version = import 'version.libsonnet';
+
 local cluster_dns = {
   cloudscale: '${module.cluster.dns_entries}',
   exoscale: '${module.cluster.ns_records}',
 };
-
-// Cutoff major versions for Terraform older than 1.3.0
-// With Terraform < 1.3.0, we only support major module versions < the values
-// here, while with Terraform >= 1.3.0 we only support major module versions
-// >= the values here.
-local module_cutoff_major_versions = {
-  cloudscale: 4,
-  exoscale: 3,
-};
-
-// This evaluates to a boolean indicating whether the configured Terraform
-// version is >= 1.3.0.
-local tf_1_3 =
-  local terraformVersion = std.split(params.images.terraform.tag, '.');
-  if std.length(terraformVersion) < 3 then
-    error 'Unable to parse Terraform image tag'
-  else
-    local parsedTfVersion = std.map(std.parseInt, terraformVersion);
-    if parsedTfVersion[0] > 1 then
-      error "Component doesn't support Terraform 2.x"
-    else
-      if parsedTfVersion[0] == 1 && parsedTfVersion[1] >= 3 then
-        true
-      else
-        false;
-
-// This evaluates to a boolean indicating whether the configured combination
-// of Terraform version, module version, and cloud provider is supported.
-local tfModuleMajorVersion =
-  local verParts = std.split(params.version, '.');
-  if std.length(verParts) < 3 then
-    // probably not a tagged version, just return the minimum supported
-    // version for Terraform 1.3
-    module_cutoff_major_versions[params.provider]
-  else
-    std.parseInt(std.lstripChars(verParts[0], 'v'));
-
-local supported_module_version =
-  local paramsMajor = tfModuleMajorVersion;
-  if tf_1_3 then
-    // for Terraform >= 1.3.0 we need at least the cutoff module major
-    // version
-    paramsMajor >= module_cutoff_major_versions[params.provider]
-  else
-    // for Terraform < 1.3.0 we need a module major version < the cutoff
-    // version
-    paramsMajor < module_cutoff_major_versions[params.provider];
 
 // Configure Terraform input variables which are provided at runtime
 local input_vars = {
@@ -73,7 +28,7 @@ local input_vars = {
     control_vshn_net_token: {
       default: '',
     },
-  } + if tfModuleMajorVersion > 3 && tfModuleMajorVersion < 5 then {
+  } + if version.tfModuleMajorVersion > 3 && version.tfModuleMajorVersion < 5 then {
     lb_exoscale_api_key: {
       default: '',
     },
@@ -138,20 +93,6 @@ local terraform_config =
 if std.member(std.objectFields(cluster_dns), params.provider) == false then
   error 'openshift4_terraform.provider "' + params.provider + '" is not supported by this component. Currently supported are ' + std.objectFields(cluster_dns) + '. If you think this is a bug in the component, file an issue on https://github.com/appuio/component-openshift4-terraform.'
 else
-  if !supported_module_version then
-    // Generate a compilation error if the combination of Terraform version,
-    // module version and cloud provider is not supported.
-    local verLimit =
-      if tf_1_3 then
-        module_cutoff_major_versions[params.provider]
-      else
-        module_cutoff_major_versions[params.provider] - 1;
-    error 'The %s supported Terraform module version for provider "%s" is `v%d.0.0` for Terraform version `%s`' % [
-      if tf_1_3 then 'minimum' else 'maximum',
-      params.provider,
-      verLimit,
-      params.images.terraform.tag,
-    ]
-  else
-    // output
-    terraform_config
+  // Check whether combination of Terraform version and module version is
+  // valid.
+  version.check(terraform_config)

--- a/component/version.libsonnet
+++ b/component/version.libsonnet
@@ -1,0 +1,74 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_terraform;
+
+// Cutoff major versions for Terraform older than 1.3.0
+// With Terraform < 1.3.0, we only support major module versions < the values
+// here, while with Terraform >= 1.3.0 we only support major module versions
+// >= the values here.
+local module_cutoff_major_versions = {
+  cloudscale: 4,
+  exoscale: 3,
+};
+
+// This evaluates to a boolean indicating whether the configured Terraform
+// version is >= 1.3.0.
+local tf_1_3 =
+  local terraformVersion = std.split(params.images.terraform.tag, '.');
+  if std.length(terraformVersion) < 3 then
+    error 'Unable to parse Terraform image tag'
+  else
+    local parsedTfVersion = std.map(std.parseInt, terraformVersion);
+    if parsedTfVersion[0] > 1 then
+      error "Component doesn't support Terraform 2.x"
+    else
+      if parsedTfVersion[0] == 1 && parsedTfVersion[1] >= 3 then
+        true
+      else
+        false;
+
+// This evaluates to a boolean indicating whether the configured combination
+// of Terraform version, module version, and cloud provider is supported.
+local tfModuleMajorVersion =
+  local verParts = std.split(params.version, '.');
+  if std.length(verParts) < 3 then
+    // probably not a tagged version, just return the minimum supported
+    // version for Terraform 1.3
+    module_cutoff_major_versions[params.provider]
+  else
+    std.parseInt(std.lstripChars(verParts[0], 'v'));
+
+local supported_module_version =
+  local paramsMajor = tfModuleMajorVersion;
+  if tf_1_3 then
+    // for Terraform >= 1.3.0 we need at least the cutoff module major
+    // version
+    paramsMajor >= module_cutoff_major_versions[params.provider]
+  else
+    // for Terraform < 1.3.0 we need a module major version < the cutoff
+    // version
+    paramsMajor < module_cutoff_major_versions[params.provider];
+
+local versionCheck(terraform_config) =
+  if !supported_module_version then
+    // Generate a compilation error if the combination of Terraform version,
+    // module version and cloud provider is not supported.
+    local verLimit =
+      if tf_1_3 then
+        module_cutoff_major_versions[params.provider]
+      else
+        module_cutoff_major_versions[params.provider] - 1;
+    error 'The %s supported Terraform module version for provider "%s" is `v%d.0.0` for Terraform version `%s`' % [
+      if tf_1_3 then 'minimum' else 'maximum',
+      params.provider,
+      verLimit,
+      params.images.terraform.tag,
+    ]
+  else
+    // output
+    terraform_config;
+
+{
+  tfModuleMajorVersion: tfModuleMajorVersion,
+  check: versionCheck,
+}

--- a/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
+++ b/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
@@ -58,5 +58,3 @@ variables:
   TF_ADDRESS: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/terraform/state/cluster
   TF_ROOT: ${CI_PROJECT_DIR}/manifests/openshift4-terraform
   TF_VAR_control_vshn_net_token: ${CONTROL_VSHN_NET_TOKEN}
-  TF_VAR_lb_exoscale_api_key: ${EXOSCALE_FLOATY_KEY}
-  TF_VAR_lb_exoscale_api_secret: ${EXOSCALE_FLOATY_SECRET}


### PR DESCRIPTION
2755222ebf9c54aad02303f0b6307c8ae72b4750 just refactors the version checking so that we can reuse it. The actual bug fix is in e042e31be190b4ea39486dbf53aeecba193b8f84

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
