### PR TITLE
Use unrestricted credentials in Exoscale gitlab-ci.yml

### DIFF
--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -19,8 +19,8 @@ local cloud_specific_variables = {
   },
   exoscale: {
     default: {
-      EXOSCALE_API_KEY: '${EXOSCALE_API_KEY_RO}',
-      EXOSCALE_API_SECRET: '${EXOSCALE_API_SECRET_RO}',
+      EXOSCALE_API_KEY: '${EXOSCALE_API_KEY_RW}',
+      EXOSCALE_API_SECRET: '${EXOSCALE_API_SECRET_RW}',
       TF_VAR_control_vshn_net_token: '${CONTROL_VSHN_NET_TOKEN}',
       [if std.objectHas(git, 'username') then 'GIT_AUTHOR_NAME']: git.username,
       [if std.objectHas(git, 'email') then 'GIT_AUTHOR_EMAIL']: git.email,
@@ -28,10 +28,7 @@ local cloud_specific_variables = {
       TF_VAR_lb_exoscale_api_key: '${EXOSCALE_FLOATY_KEY}',
       TF_VAR_lb_exoscale_api_secret: '${EXOSCALE_FLOATY_SECRET}',
     } else {},
-    apply: {
-      EXOSCALE_API_KEY: '${EXOSCALE_API_KEY_RW}',
-      EXOSCALE_API_SECRET: '${EXOSCALE_API_SECRET_RW}',
-    },
+    apply: {},
   },
 };
 

--- a/docs/modules/ROOT/pages/how-tos/use-exoscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-exoscale.adoc
@@ -10,41 +10,9 @@ NOTE: The component currently assumes that the Git repositories live on a GitLab
 
 == Setup credentials
 
-. Set up three new API keys in https://portal.exoscale.com[portal.exoscale.com].
-Two of them are used for the Terraform pipeline.
-.. The first key should be created with the a read-only IAM role:
-+
-.Read-only role
-[source,json]
-----
-{
-  "name": "openshift4-terraform-ro",
-  "policy": {
-    "default-service-strategy": "deny",
-    "services": {
-      "compute": {
-        "type": "rules",
-        "rules": [
-          {
-            "action": "allow",
-            "expression": "matches(operation, '(get|list)-.*')"
-          }
-        ]
-      },
-      "dns": {
-        "type": "rules",
-        "rules": [
-          {
-            "action": "allow",
-            "expression": "matches(operation, '(get|list)-.*')"
-          }
-        ]
-      }
-    }
-  }
-}
-----
-.. The second key can be created with a role with full permissions
+. Set up two new API keys in https://portal.exoscale.com[portal.exoscale.com].
+One of them is used for the Terraform pipeline.
+.. The first key needs to be created with a role with full permissions
 +
 .Full permissions role configuration
 [source,json]
@@ -54,7 +22,7 @@ Two of them are used for the Terraform pipeline.
   "policy": { "default-service-strategy": "allow" }
 }
 ----
-.. The third key needs the following IAM role (this key will be deployed onto the LBs for https://github.com/vshn/floaty[Floaty]):
+.. The second key needs the following IAM role (this key will be deployed onto the LBs for https://github.com/vshn/floaty[Floaty]):
 +
 .Floaty IAM role
 [source,json]
@@ -118,8 +86,6 @@ Please note that the Terraform module currently only supports the https://git.vs
   - "Settings > CI/CD > General pipelines > Configuration file" +
     `manifests/openshift4-terraform/gitlab-ci.yml`
   - "Settings > CI/CD > Variables"
-    * `EXOSCALE_API_SECRET_RO`
-    * `EXOSCALE_API_KEY_RO`
     * `EXOSCALE_API_SECRET_RW`
     * `EXOSCALE_API_KEY_RW`
     * `EXOSCALE_FLOATY_KEY`

--- a/tests/golden/exoscale-v4/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
+++ b/tests/golden/exoscale-v4/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
@@ -10,9 +10,7 @@ apply:
     - export GIT_ASKPASS=${TF_ROOT}/git-askpass.sh
     - gitlab-terraform apply
   stage: deploy
-  variables:
-    EXOSCALE_API_KEY: ${EXOSCALE_API_KEY_RW}
-    EXOSCALE_API_SECRET: ${EXOSCALE_API_SECRET_RW}
+  variables: {}
   when: manual
 default:
   before_script:
@@ -53,8 +51,8 @@ validate:
     - gitlab-terraform validate
   stage: validate
 variables:
-  EXOSCALE_API_KEY: ${EXOSCALE_API_KEY_RO}
-  EXOSCALE_API_SECRET: ${EXOSCALE_API_SECRET_RO}
+  EXOSCALE_API_KEY: ${EXOSCALE_API_KEY_RW}
+  EXOSCALE_API_SECRET: ${EXOSCALE_API_SECRET_RW}
   TF_ADDRESS: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/terraform/state/cluster
   TF_ROOT: ${CI_PROJECT_DIR}/manifests/openshift4-terraform
   TF_VAR_control_vshn_net_token: ${CONTROL_VSHN_NET_TOKEN}

--- a/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
+++ b/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
@@ -10,9 +10,7 @@ apply:
     - export GIT_ASKPASS=${TF_ROOT}/git-askpass.sh
     - gitlab-terraform apply
   stage: deploy
-  variables:
-    EXOSCALE_API_KEY: ${EXOSCALE_API_KEY_RW}
-    EXOSCALE_API_SECRET: ${EXOSCALE_API_SECRET_RW}
+  variables: {}
   when: manual
 default:
   before_script:
@@ -53,8 +51,8 @@ validate:
     - gitlab-terraform validate
   stage: validate
 variables:
-  EXOSCALE_API_KEY: ${EXOSCALE_API_KEY_RO}
-  EXOSCALE_API_SECRET: ${EXOSCALE_API_SECRET_RO}
+  EXOSCALE_API_KEY: ${EXOSCALE_API_KEY_RW}
+  EXOSCALE_API_SECRET: ${EXOSCALE_API_SECRET_RW}
   TF_ADDRESS: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/terraform/state/cluster
   TF_ROOT: ${CI_PROJECT_DIR}/manifests/openshift4-terraform
   TF_VAR_control_vshn_net_token: ${CONTROL_VSHN_NET_TOKEN}


### PR DESCRIPTION
Replace read-only credentials with unrestricted ones, when using Exoscale.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
