### PR TITLE
Drop the read-only cloudscale token, add token naming convention

### DIFF
--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -7,15 +7,13 @@ local version = import 'version.libsonnet';
 local cloud_specific_variables = {
   cloudscale: {
     default: {
-      CLOUDSCALE_API_TOKEN: '${CLOUDSCALE_TOKEN_RO}',
+      CLOUDSCALE_API_TOKEN: '${CLOUDSCALE_TOKEN_RW}',
       TF_VAR_lb_cloudscale_api_secret: '${CLOUDSCALE_FLOATY_SECRET}',
       TF_VAR_control_vshn_net_token: '${CONTROL_VSHN_NET_TOKEN}',
       [if std.objectHas(git, 'username') then 'GIT_AUTHOR_NAME']: git.username,
       [if std.objectHas(git, 'email') then 'GIT_AUTHOR_EMAIL']: git.email,
     },
-    apply: {
-      CLOUDSCALE_API_TOKEN: '${CLOUDSCALE_TOKEN_RW}',
-    },
+    apply: {},
   },
   exoscale: {
     default: {

--- a/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
+++ b/docs/modules/ROOT/pages/how-tos/use-cloudscale.adoc
@@ -10,11 +10,11 @@ NOTE: The component currently assumes that the Git repositories live on a GitLab
 
 == Setup credentials
 
-. Set up 3 new API keys in https://control.cloudscale.ch[control.cloudscale.ch].
-  Two of them are used for the Terraform pipeline.
-.. The first key should be created with read-only permissions and will be used for read-only GitLab CI jobs.
-.. The second key can be created with read/write permissions and will be used for mutating GitLab CI jobs but also for the initial cluster installation.
-.. The third key needs read/write permissions and will be deployed onto the LBs for https://github.com/vshn/floaty[Floaty]):
+NOTE: Don't create new tokens for clusters already set up with the standard install instructions. Use the existing ones stored in vault under `/cloudscale` and `/floaty`.
+
+. Set up 2 new API tokens with read+write permissions in https://control.cloudscale.ch[control.cloudscale.ch].
+.. The first token should be named `${CLUSTER_ID}` and will be used for the initial cluster setup, the cluster's CSI driver and GitLab CI jobs.
+.. The second token should be named `${CLUSTER_ID}_floaty` and will be deployed onto the LBs for https://github.com/vshn/floaty[Floaty]).
 
 include::partial$puppet-lb-cred.adoc[]
 
@@ -55,7 +55,6 @@ Please note that the Terraform module currently only supports the https://git.vs
   - "Settings > CI/CD > General pipelines > Configuration file" +
     `manifests/openshift4-terraform/gitlab-ci.yml`
   - "Settings > CI/CD > Variables"
-    * `CLOUDSCALE_TOKEN_RO`
     * `CLOUDSCALE_TOKEN_RW`
     * `CLOUDSCALE_FLOATY_SECRET`
     * `HIERADATA_REPO_TOKEN` -- the VSHN APPUiO hieradata project access token

--- a/tests/golden/cloudscale/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
+++ b/tests/golden/cloudscale/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
@@ -10,8 +10,7 @@ apply:
     - export GIT_ASKPASS=${TF_ROOT}/git-askpass.sh
     - gitlab-terraform apply
   stage: deploy
-  variables:
-    CLOUDSCALE_API_TOKEN: ${CLOUDSCALE_TOKEN_RW}
+  variables: {}
   when: manual
 default:
   before_script:
@@ -52,7 +51,7 @@ validate:
     - gitlab-terraform validate
   stage: validate
 variables:
-  CLOUDSCALE_API_TOKEN: ${CLOUDSCALE_TOKEN_RO}
+  CLOUDSCALE_API_TOKEN: ${CLOUDSCALE_TOKEN_RW}
   TF_ADDRESS: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/terraform/state/cluster
   TF_ROOT: ${CI_PROJECT_DIR}/manifests/openshift4-terraform
   TF_VAR_control_vshn_net_token: ${CONTROL_VSHN_NET_TOKEN}


### PR DESCRIPTION
See also #95, internal reference OCP-635

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
