### PR TITLE
Update Terraform modules to provision new LBs with Ubuntu 22.04

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,8 +3,8 @@ parameters:
     =_metadata:
       multi_tenant: false
     =_tf_module_version:
-      cloudscale: v4.5.2
-      exoscale: v6.0.0
+      cloudscale: v4.6.0
+      exoscale: v6.1.0
     images:
       terraform:
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/terraform

--- a/tests/golden/cloudscale/openshift4-terraform/openshift4-terraform/main.tf.json
+++ b/tests/golden/cloudscale/openshift4-terraform/openshift4-terraform/main.tf.json
@@ -9,7 +9,7 @@
       "ignition_ca": "SomeCertificateString",
       "lb_cloudscale_api_secret": "${var.lb_cloudscale_api_secret}",
       "region": "rma",
-      "source": "git::https://github.com/appuio/terraform-openshift4-cloudscale.git//?ref=v4.5.2",
+      "source": "git::https://github.com/appuio/terraform-openshift4-cloudscale.git//?ref=v4.6.0",
       "ssh_keys": [
         "ssh-ed25519 AA..."
       ]

--- a/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/main.tf.json
+++ b/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/main.tf.json
@@ -9,7 +9,7 @@
       "ignition_ca": "SomeCertificateString",
       "region": "ch-dk-2",
       "rhcos_template": "my-iso-image",
-      "source": "git::https://github.com/appuio/terraform-openshift4-exoscale.git//?ref=v6.0.0",
+      "source": "git::https://github.com/appuio/terraform-openshift4-exoscale.git//?ref=v6.1.0",
       "ssh_key": "ssh-ed25519 AA..."
     }
   }


### PR DESCRIPTION
terraform-openshift4-exoscale v6.1.0 also fixes a bug with cluster bootstrapping when `use_instancepools=true`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
