### PR TITLE
Update Exoscale Terraform module to v7.0.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,7 +4,7 @@ parameters:
       multi_tenant: false
     =_tf_module_version:
       cloudscale: v4.6.0
-      exoscale: v6.1.0
+      exoscale: v7.0.0
     images:
       terraform:
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/terraform

--- a/docs/modules/ROOT/pages/how-tos/upgrade-exoscale-to-v9.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-exoscale-to-v9.adoc
@@ -1,0 +1,21 @@
+= Upgrade Exoscale clusters to component version v9
+
+When upgrading to component version v9 for Exoscale clusters, the following breaking change may require manual changes in the Project Syn config of existing clusters:
+
+* https://github.com/appuio/terraform-openshift4-exoscale/pull/105[Switch infra nodes to non-instancepool by default]
+
+IMPORTANT: The config changes outlined in this guide must be applied at the same time as the upgrade to component version v9.
+
+TIP: We will publish a guide to migrate existing clusters to use instance pools in a future version of this component.
+
+== Steps
+
+. Get a clone of the tenant repo of the clusters that you want to upgrade to component version v9.
+
+. Make sure component `openshift4-terraform` is updated to at least v9.0.0 so the variable `infra_use_instancepool` exists
+
+. Set `parameters.openshift4_terraform.variables.infra_use_instancepool` to `true` for existing clusters which have been setup with instancepools for the worker and infra nodes.
++
+TIP: The variable `infra_use_instancepool` has no effect for clusters which set variabl `use_instancepools` to `false`.
+
+. Commit the changes

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -9,6 +9,7 @@
 * xref:how-tos/upgrade-exoscale-v4-v5.adoc[Upgrade Exoscale clusters from component version v4 to v5]
 * xref:how-tos/upgrade-exoscale-to-v7.adoc[Upgrade Exoscale clusters to component version v7]
 * xref:how-tos/upgrade-exoscale-to-v8.adoc[Upgrade Exoscale clusters to component version v8]
+* xref:how-tos/upgrade-exoscale-to-v9.adoc[Upgrade Exoscale clusters to component version v9]
 * xref:how-tos/migrate-from-openshift4-cloudscale.adoc[Migrate from component `openshift4-cloudscale`]
 
 .Technical reference

--- a/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/main.tf.json
+++ b/tests/golden/exoscale/openshift4-terraform/openshift4-terraform/main.tf.json
@@ -9,7 +9,7 @@
       "ignition_ca": "SomeCertificateString",
       "region": "ch-dk-2",
       "rhcos_template": "my-iso-image",
-      "source": "git::https://github.com/appuio/terraform-openshift4-exoscale.git//?ref=v6.1.0",
+      "source": "git::https://github.com/appuio/terraform-openshift4-exoscale.git//?ref=v7.0.0",
       "ssh_key": "ssh-ed25519 AA..."
     }
   }


### PR DESCRIPTION
This is a breaking change for existing OCP clusters which use `use_instancepools = true`. To preserve the v6 behavior, users need to set `infra_use_instancepool = true` for clusters which currently use an instance pool for the infra nodes.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
