### PR TITLE
Add support for terraform-openshift4-stackit

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "f12cbb49f928cf689cf39b98d8d7c9e88fb289f6",
+  "commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "openshift4-terraform",
       "slug": "openshift4-terraform",
       "parameter_key": "openshift4_terraform",
-      "test_cases": "cloudscale exoscale exoscale-v4",
+      "test_cases": "cloudscale exoscale exoscale-v4 stackit",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
@@ -24,7 +24,8 @@
       "github_owner": "appuio",
       "github_name": "component-openshift4-terraform",
       "github_url": "https://github.com/appuio/component-openshift4-terraform",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
     }
   },
   "directory": null

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
           - cloudscale
           - exoscale
           - exoscale-v4
+          - stackit
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -52,6 +53,7 @@ jobs:
           - cloudscale
           - exoscale
           - exoscale-v4
+          - stackit
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -53,4 +53,4 @@ TERRAFORM_IMAGE ?= $(shell grep image: class/defaults.yml | sed 's/ *//g' | cut 
 TERRAFORM_CMD   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(compiled_volume) $(extra_args) $(TERRAFORM_IMAGE)
 
 instance ?= cloudscale
-test_instances = tests/cloudscale.yml tests/exoscale.yml tests/exoscale-v4.yml
+test_instances = tests/cloudscale.yml tests/exoscale.yml tests/exoscale-v4.yml tests/stackit.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,6 +5,7 @@ parameters:
     =_tf_module_version:
       cloudscale: v4.6.0
       exoscale: v7.1.0
+      stackit: v0.1.0
     images:
       terraform:
         image: registry.gitlab.com/gitlab-org/terraform-images/releases/terraform

--- a/component/gitlab-ci.jsonnet
+++ b/component/gitlab-ci.jsonnet
@@ -28,6 +28,10 @@ local cloud_specific_variables = {
     } else {},
     apply: {},
   },
+  stackit: {
+    default: {},
+    apply: {},
+  },
 };
 
 local GitLabCI() = {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -50,7 +50,7 @@ local common_outputs = {
 };
 local outputs = {
   cloudscale: common_outputs {
-    'hieradata_mr': '${module.cluster.hieradata_mr}',
+    hieradata_mr: '${module.cluster.hieradata_mr}',
     'master-machines_yml': '${module.cluster.master-machines_yml}',
     'master-machineset_yml': '${module.cluster.master-machineset_yml}',
     'infra-machines_yml': '${module.cluster.infra-machines_yml}',
@@ -61,7 +61,7 @@ local outputs = {
     'additional-worker-machinesets_yml': '${module.cluster.additional-worker-machinesets_yml}',
   },
   exoscale: common_outputs {
-    'hieradata_mr': '${module.cluster.hieradata_mr}',
+    hieradata_mr: '${module.cluster.hieradata_mr}',
   },
   stackit: common_outputs,
 };

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -9,6 +9,7 @@ local version = import 'version.libsonnet';
 local cluster_dns = {
   cloudscale: '${module.cluster.dns_entries}',
   exoscale: '${module.cluster.ns_records}',
+  stackit: '${module.cluster.ns_records}',
 };
 
 // Configure Terraform input variables which are provided at runtime
@@ -36,15 +37,20 @@ local input_vars = {
       default: '',
     },
   } else {},
+  stackit: {
+    ignition_bootstrap: {
+      default: '',
+    },
+  },
 };
 
 // Configure Terraform outputs
 local common_outputs = {
   cluster_dns: cluster_dns[params.provider],
-  hieradata_mr: '${module.cluster.hieradata_mr}',
 };
 local outputs = {
   cloudscale: common_outputs {
+    'hieradata_mr': '${module.cluster.hieradata_mr}',
     'master-machines_yml': '${module.cluster.master-machines_yml}',
     'master-machineset_yml': '${module.cluster.master-machineset_yml}',
     'infra-machines_yml': '${module.cluster.infra-machines_yml}',
@@ -54,7 +60,10 @@ local outputs = {
     'additional-worker-machines_yml': '${module.cluster.additional-worker-machines_yml}',
     'additional-worker-machinesets_yml': '${module.cluster.additional-worker-machinesets_yml}',
   },
-  exoscale: common_outputs,
+  exoscale: common_outputs {
+    'hieradata_mr': '${module.cluster.hieradata_mr}',
+  },
+  stackit: common_outputs,
 };
 
 // We want to pass through any provider-specific input variables (see above)

--- a/component/version.libsonnet
+++ b/component/version.libsonnet
@@ -9,6 +9,7 @@ local params = inv.parameters.openshift4_terraform;
 local module_cutoff_major_versions = {
   cloudscale: 4,
   exoscale: 3,
+  stackit: 0,
 };
 
 // This evaluates to a boolean indicating whether the configured Terraform

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -7,7 +7,7 @@ The parent key for all of the following parameters is `openshift4_terraform`.
 [horizontal]
 type:: enum
 required:: Yes
-values:: `cloudscale`, `exoscale`
+values:: `cloudscale`, `exoscale`, `stackit`
 default:: `${facts:cloud}`
 
 This variable is used to select the Terraform module and a suitable default configuration for the specified cloud provider.
@@ -15,6 +15,7 @@ The supported providers are:
 
 - https://cloudscale.ch[Cloudscale.ch] -- https://github.com/appuio/terraform-openshift4-cloudscale[Terraform module]
 - https://exoscale.com[Exoscale] -- https://github.com/appuio/terraform-openshift4-exoscale[Terraform module]
+- https://stackit.cloud[STACKIT] -- https://github.com/appuio/terraform-openshift4-stackit[Terraform module]
 
 == `gitlab_ci.tags`
 
@@ -98,3 +99,4 @@ See examples in the how-to pages:
 
 * xref:how-tos/use-cloudscale.adoc[cloudscale.ch example]
 * xref:how-tos/use-exoscale.adoc[Exoscale example]
+* xref:how-tos/use-stackit.adoc[STACKIT example]

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -3,6 +3,7 @@
 .How-to guides
 * xref:how-tos/use-cloudscale.adoc[Use cloudscale.ch]
 * xref:how-tos/use-exoscale.adoc[Use Exoscale]
+* xref:how-tos/use-stackit.adoc[Use STACKIT]
 * xref:how-tos/upgrade-cloudscale-v1-v2.adoc[Upgrade cloudscale.ch from v1 to v2]
 * xref:how-tos/upgrade-cloudscale-v2-v3.adoc[Upgrade cloudscale.ch from v2 to v3]
 * xref:how-tos/upgrade-exoscale-v3-v4.adoc[Upgrade Exoscale clusters from component version v3 to v4]

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/.gitignore
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/backend.tf.json
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/backend.tf.json
@@ -1,0 +1,7 @@
+{
+  "terraform": {
+    "backend": {
+      "http": {}
+    }
+  }
+}

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/git-askpass.sh
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/git-askpass.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec echo "$HIERADATA_REPO_TOKEN"

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/gitlab-ci.yml
@@ -1,0 +1,54 @@
+apply:
+  dependencies:
+    - plan
+  environment:
+    name: production
+  only:
+    - master
+  script:
+    - apk add --no-cache curl
+    - export GIT_ASKPASS=${TF_ROOT}/git-askpass.sh
+    - gitlab-terraform apply
+  stage: deploy
+  variables: {}
+  when: manual
+default:
+  before_script:
+    - cd ${TF_ROOT}
+    - gitlab-terraform init
+  cache:
+    key: ${CI_PIPELINE_ID}
+    paths:
+      - ${TF_ROOT}/.terraform/modules
+      - ${TF_ROOT}/.terraform/plugins
+  image: registry.gitlab.com/gitlab-org/terraform-images/releases/terraform:1.5.7
+  tags: []
+format:
+  before_script: []
+  cache: {}
+  script:
+    - terraform fmt -recursive -diff -check ${TF_ROOT}
+  stage: validate
+plan:
+  artifacts:
+    expire_in: 1 week
+    name: plan
+    paths:
+      - ${TF_ROOT}/plan.cache
+    reports:
+      terraform: ${TF_ROOT}/plan.json
+  script:
+    - gitlab-terraform plan
+    - gitlab-terraform plan-json
+  stage: plan
+stages:
+  - validate
+  - plan
+  - deploy
+validate:
+  script:
+    - gitlab-terraform validate
+  stage: validate
+variables:
+  TF_ADDRESS: ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/terraform/state/cluster
+  TF_ROOT: ${CI_PROJECT_DIR}/manifests/openshift4-terraform

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/main.tf.json
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/main.tf.json
@@ -1,0 +1,15 @@
+{
+  "module": {
+    "cluster": {
+      "base_domain": "stackit.ch",
+      "cluster_id": "c-green-test-1234",
+      "ignition_bootstrap": "${var.ignition_bootstrap}",
+      "ignition_ca": "SomeCertificateString",
+      "image_id": "some-image-uuid",
+      "region": "eu01",
+      "source": "git::https://github.com/appuio/terraform-openshift4-stackit.git//?ref=v0.1.0",
+      "ssh_key": "ssh-ed25519 AA...",
+      "stackit_project_id": "some-project-uuid"
+    }
+  }
+}

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/migrate-state-exoscale-v3-v4.sh
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/migrate-state-exoscale-v3-v4.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+#
+# Migrate Exoscale Terraform state
+#
+
+# Floating IPs
+terraform state mv module.cluster.exoscale_ipaddress.api module.cluster.module.lb.exoscale_ipaddress.api
+terraform state mv module.cluster.exoscale_ipaddress.ingress module.cluster.module.lb.exoscale_ipaddress.ingress
+# DNS records
+terraform state mv module.cluster.exoscale_domain_record.api module.cluster.module.lb.exoscale_domain_record.api
+terraform state mv module.cluster.exoscale_domain_record.ingress module.cluster.module.lb.exoscale_domain_record.ingress
+terraform state mv module.cluster.exoscale_domain_record.lb module.cluster.module.lb.exoscale_domain_record.lb
+# Security group
+terraform state mv module.cluster.exoscale_security_group.load_balancers module.cluster.module.lb.exoscale_security_group.load_balancers
+terraform state mv module.cluster.exoscale_security_group_rules.load_balancers module.cluster.module.lb.exoscale_security_group_rules.load_balancers
+# LBs
+terraform state mv module.cluster.exoscale_affinity.lb module.cluster.module.lb.exoscale_affinity.lb
+terraform state mv module.cluster.random_id.lb module.cluster.module.lb.random_id.lb
+terraform state mv module.cluster.exoscale_compute.lb module.cluster.module.lb.exoscale_compute.lb
+terraform state mv module.cluster.null_resource.register_lb module.cluster.module.lb.null_resource.register_lb
+terraform state mv module.cluster.exoscale_nic.lb module.cluster.module.lb.exoscale_nic.lb
+# Hieradata config
+terraform state mv module.cluster.data.local_file.hieradata_mr_url 'module.cluster.module.lb.module.hiera[0].data.local_file.hieradata_mr_url[0]'
+terraform state mv 'module.cluster.gitfile_checkout.appuio_hieradata[0]' 'module.cluster.module.lb.module.hiera[0].gitfile_checkout.appuio_hieradata'
+terraform state mv 'module.cluster.local_file.lb_hieradata[0]' 'module.cluster.module.lb.module.hiera[0].local_file.lb_hieradata'
+# private network
+terraform state mv module.cluster.exoscale_network.clusternet 'module.cluster.module.lb.exoscale_network.lbnet[0]'

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/migrate-state-exoscale-v4-v5.py
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/migrate-state-exoscale-v4-v5.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+
+# pragma pylint: disable=line-too-long,missing-module-docstring,missing-function-docstring,invalid-name
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from collections import namedtuple
+from typing import Optional
+
+dry_run = False
+
+
+def read_main_tf_json() -> dict:
+    with open("main.tf.json", "r", encoding="utf-8") as f:
+        return json.load(f)["module"]["cluster"]
+
+
+def read_node_count(state: dict, module: str) -> int:
+    if "exoscale_compute" in state[module]:
+        return len(state[module]["exoscale_compute"]["nodes"]["instances"])
+    return 0
+
+
+def read_state_json(raw_state: dict) -> dict:
+    state = {}
+    for r in raw_state["resources"]:
+        state.setdefault(r["module"], {}).setdefault(r["type"], {})[r["name"]] = r
+    return state
+
+
+def terraform_state_pull() -> dict:
+    res = subprocess.run(
+        ["terraform", "state", "pull"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    res.check_returncode()
+    return read_state_json(json.loads(res.stdout))
+
+
+def terraform_state_rm(res: str, log: bool = False):
+    if log:
+        print(f"Removing {res}", file=sys.stderr)
+
+    command = ["terraform", "state", "rm", res]
+    if dry_run:
+        print(command)
+        return
+
+    res = subprocess.run(
+        command, capture_output=True, text=True, encoding="utf-8", check=False
+    )
+    res.check_returncode()
+    if "Successfully removed" not in res.stdout:
+        print(res.stdout, sys.stderr)
+        raise ValueError(f"couldn't remove provided resource {res}")
+
+
+def terraform_import(res: str, terraform_id: str):
+    command = ["terraform", "import", res, terraform_id]
+    if dry_run:
+        print(command)
+        return
+
+    res = subprocess.run(
+        command, capture_output=True, text=True, encoding="utf-8", check=False
+    )
+    res.check_returncode()
+    if "Import prepared!" not in res.stdout:
+        print(res.stdout, file=sys.stderr)
+        raise ValueError(f"couldn't import provided resource {res} from {terraform_id}")
+
+
+# pylint: disable=too-many-arguments
+def migrate_simple_resource(
+    state: dict,
+    module: str,
+    oldtype: str,
+    newtype: str,
+    name: str,
+    index: int = 0,
+    zone: str = "",
+):
+    """Migrate a single resource from `oldtype` to `newtype` by removing the old
+    type from the state with `terraform state rm` and importing the resource
+    with it's new type with `terraform import`. This function assumes that all
+    other parts of the resource (it's module, name and index) remain the same.
+
+    The function supports migrating resources at arbitrary indices (e.g. for
+    node groups, we can call this function repeatedly to migrate each node's
+    state) by providing `index`. By default the resource at index 0 is migrated.
+
+    For resources whose state identifiers don't have an index (i.e. which are
+    referred by `<module>.<type>.<name>` in the state, you can pass `index=-1`,
+    which omits the `[0]` from their state identifier. In this case, we still
+    read from `instances[0].attributes` to identify the resource's Exoscale ID.
+
+    If `zone` is given, we import the resource as `<Exoscale ID>@<zone>`,
+    otherwise we import it as `<Exoscale ID>`.
+    """
+    # Assumption structure of resource has `attributes` array with at least one entry
+    resid = (
+        state[module]
+        .get(oldtype, {})
+        .get(name, {"instances": [{"attributes": {"id": None}}] * (max(index, 0) + 1)})
+    )["instances"][max(index, 0)]["attributes"]["id"]
+
+    # Append [{index}] to resource identifier if index >= 0
+    res_suffix = ""
+    if index >= 0:
+        res_suffix = f"[{index}]"
+
+    old_res_loc = f"{module}.{oldtype}.{name}{res_suffix}"
+    new_res_loc = f"{module}.{newtype}.{name}{res_suffix}"
+
+    if resid:
+        exo_id = f"{resid}@{zone}" if zone else resid
+        print(
+            f"Migrating {old_res_loc} to {new_res_loc} (Exoscale ID: {exo_id})",
+            file=sys.stderr,
+        )
+        terraform_state_rm(old_res_loc)
+        terraform_import(new_res_loc, exo_id)
+
+
+RuleSpec = namedtuple("RuleSpec", ["exo_id", "proto", "source", "portspec"])
+
+
+def parse_sg_rule_id(rid: str) -> RuleSpec:
+    id_parts = rid.split("_")
+
+    exo_id = id_parts[0]
+    proto = id_parts[1]
+    source = "_".join(id_parts[2:-1])
+    portspec = id_parts[-1]
+
+    return RuleSpec(exo_id, proto, source, portspec)
+
+
+def migrate_security_group_rules_all_machines(state: dict):
+    # Rule map: old description + portspec -> new description
+    # Special cases: old description + portspec -> new resource name suffix
+    _rules_map = {
+        "VXLAN and GENEVE": {
+            "4789-4789": "openshift-sdn/OVNKubernetes VXLAN",
+            "6081-6081": "openshift-sdn/OVNKubernetes GENEVE",
+        },
+        "SSH Access": {
+            "22-22": "",
+        },
+        "ICMP Ping": {
+            "8:0": "",
+        },
+        "Cilium Hubble Enterprise metrics": {
+            "2112-2112": "Cilium Hubble Enterprise metrics",
+        },
+        "Cilium Hubble Relay": {
+            "4245-4245": "Cilium Hubble Relay",
+        },
+        "Cilium Hubble Server": {
+            "4244-4244": "Cilium Hubble Server",
+        },
+        "Cilium VXLAN": {
+            "8472-8472": "Cilium VXLAN",
+        },
+        "Cilium Operator Prometheus metrics": {
+            "6942-6942": "Cilium Operator Prometheus metrics",
+        },
+        "Cilium health checks": {
+            "4240-4240": "Cilium health checks",
+        },
+        "Host level services, including the node exporter on ports 9100-9101 and the Cluster Version Operator on port 9099": {
+            "9000-9999": "Host level services, including the node exporter on ports 9100-9101 and the Cluster Version Operator on port 9099",
+        },
+        "Host level services, including the node exporter on ports 9100-9101": {
+            "9000-9999": "Host level services, including the node exporter on ports 9100-9101",
+        },
+        "Ingress Router metrics": {
+            "1936-1936": "Ingress Router metrics",
+        },
+        "Kubernetes NodePort TCP": {
+            "30000-32767": "Kubernetes NodePort TCP",
+        },
+        "Kubernetes NodePort UDP": {
+            "30000-32767": "Kubernetes NodePort UDP",
+        },
+        "The default ports that Kubernetes reserves": {
+            "10250-10259": "The default ports that Kubernetes reserves, including the openshift-sdn port",
+        },
+    }
+    sg_id = state["module.cluster"]["exoscale_security_group"]["all_machines"][
+        "instances"
+    ][0]["attributes"]["id"]
+    rules = state["module.cluster"]["exoscale_security_group_rules"]["all_machines"][
+        "instances"
+    ][0]["attributes"]["ingress"]
+    for r in rules:
+        desc = r["description"]
+        if desc == "openshift-sdn":
+            print(
+                "Dropping superfluous openshift-sdn rule for port 10256",
+                file=sys.stderr,
+            )
+            continue
+        new_rules = _rules_map[desc]
+        for rid in r["ids"]:
+            # Example rid:
+            # 0abf6f67-4782-432e-8510-a0d7e7f2fab4_udp_c-appuio-exoscale-ch-gva-2-0_all_machines_4789-4789
+            rspec = parse_sg_rule_id(rid)
+
+            resid_base = "module.cluster.exoscale_security_group_rule"
+
+            if rspec.proto == "icmp":
+                # special case icmp rules
+                resid = f"{resid_base}.all_machines_icmp"
+            elif desc == "SSH Access":
+                # special case ssh rules
+                ipver = None
+                if rspec.source == "::/0":
+                    ipver = "v6"
+                elif rspec.source == "0.0.0.0/0":
+                    ipver = "v4"
+                else:
+                    print(
+                        f"Unknown ssh rule source {rspec.source}, skipping",
+                        file=sys.stderr,
+                    )
+                    continue
+                resid = f"{resid_base}.all_machines_ssh_{ipver}"
+            else:
+                new_desc = new_rules[rspec.portspec]
+                resid = f'{resid_base}.all_machines_{rspec.proto}["{new_desc}"]'
+
+            print(
+                f"Importing security group rule {resid} (Exoscale ID: {rspec.exo_id})",
+                file=sys.stderr,
+            )
+            terraform_import(resid, f"{sg_id}/{rspec.exo_id}")
+
+
+def migrate_security_group_rules_simple(state: dict, groupname: str):
+    # rule map: portspec -> new resouce name
+    rule_map = {
+        "control_plane": {
+            "6443-6443": "control_plane_kubernetes_api",
+            "22623-22623": "control_plane_machine_config_server",
+            "2379-2380": "control_plane_etcd",
+        },
+        "infra": {
+            "80-80": 'infra["HTTP"]',
+            "443-443": 'infra["HTTPS"]',
+        },
+        "storage": {
+            "3300-3300": 'storage["Ceph Messenger v1"]',
+            "6789-6789": 'storage["Ceph Messenger v2"]',
+            "6800-7300": 'storage["Ceph daemons"]',
+        },
+    }[groupname]
+    sg_id = state["module.cluster"]["exoscale_security_group"][groupname]["instances"][
+        0
+    ]["attributes"]["id"]
+    rules = state["module.cluster"]["exoscale_security_group_rules"][groupname][
+        "instances"
+    ][0]["attributes"]["ingress"]
+
+    for r in rules:
+        for rid in r["ids"]:
+            rspec = parse_sg_rule_id(rid)
+            resname = rule_map[rspec.portspec]
+            resid = f"module.cluster.exoscale_security_group_rule.{resname}"
+
+            print(
+                f"Importing security group rule {resid} (Exoscale ID: {rspec.exo_id})",
+                file=sys.stderr,
+            )
+            terraform_import(resid, f"{sg_id}/{rspec.exo_id}")
+
+
+def migrate_security_group_rules_lb(state: dict):
+    portspec_to_desc = {
+        "80-80": "Ingress controller HTTP",
+        "443-443": "Ingress controller HTTPS",
+        "6443-6443": "Kubernetes API",
+    }
+    sg_id = state["module.cluster.module.lb"]["exoscale_security_group"][
+        "load_balancers"
+    ]["instances"][0]["attributes"]["id"]
+    rules = state["module.cluster.module.lb"]["exoscale_security_group_rules"][
+        "load_balancers"
+    ]["instances"][0]["attributes"]["ingress"]
+
+    resid_base = "module.cluster.module.lb.exoscale_security_group_rule"
+    for r in rules:
+        for rid in r["ids"]:
+            rspec = parse_sg_rule_id(rid)
+            if rspec.portspec == "22623-22623":
+                # special case machine config server rule
+                resid = f"{resid_base}.load_balancers_machine_config_server[0]"
+            else:
+                desc = portspec_to_desc[rspec.portspec]
+                if rspec.source == "0.0.0.0/0":
+                    ipver = "4"
+                elif rspec.source == "::/0":
+                    ipver = "6"
+                else:
+                    print(
+                        "Unknown source {desc.source}, skipping rule", file=sys.stderr
+                    )
+                    continue
+                resid = f'{resid_base}.load_balancers_{rspec.proto}{ipver}["{desc}"]'
+
+            print(
+                f"Importing security group rule {resid} (Exoscale ID: {rspec.exo_id})",
+                file=sys.stderr,
+            )
+            terraform_import(resid, f"{sg_id}/{rspec.exo_id}")
+
+
+# pylint: disable=too-many-branches
+def main(state_json: Optional[str]):
+    default_node_groups = ["master", "infra", "storage", "worker"]
+
+    # Read Exoscale and additional worker group names from main.tf.json
+    zone = ""
+    main_tf_json = read_main_tf_json()
+    zone = main_tf_json["region"]
+    additional_worker_groups = list(
+        main_tf_json.get("additional_worker_groups", {}).keys()
+    )
+
+    if not zone:
+        print("Unable to extract Exoscale zone from main.tf.json", file=sys.stderr)
+        sys.exit(1)
+
+    if state_json:
+        with open(state_json, "r", encoding="utf-8") as f:
+            state = read_state_json(json.load(f))
+    else:
+        state = terraform_state_pull()
+
+    if "module.cluster" not in state:
+        print('Module "cluster" not found in state, exiting...', file=sys.stderr)
+        sys.exit(1)
+
+    if "module.cluster.module.lb" not in state:
+        print('Module "cluster.lb" not found in state, exiting...', file=sys.stderr)
+        sys.exit(1)
+
+    # Floating IPs
+    for eip in ["api", "ingress"]:
+        migrate_simple_resource(
+            state,
+            "module.cluster.module.lb",
+            "exoscale_ipaddress",
+            "exoscale_elastic_ip",
+            eip,
+            # pass index=-1 to omit [{index}] from the terraform resource identifier
+            index=-1,
+            zone=zone,
+        )
+
+    # SSH key
+    migrate_simple_resource(
+        state,
+        "module.cluster",
+        "exoscale_ssh_keypair",
+        "exoscale_ssh_key",
+        "admin",
+    )
+
+    # Security group rules
+    if "exoscale_security_group_rules" in state["module.cluster"]:
+        terraform_state_rm(
+            "module.cluster.exoscale_security_group_rules.all_machines", log=True
+        )
+        migrate_security_group_rules_all_machines(state)
+        for group in ["control_plane", "infra", "storage"]:
+            terraform_state_rm(
+                f"module.cluster.exoscale_security_group_rules.{group}", log=True
+            )
+            migrate_security_group_rules_simple(state, group)
+    if "exoscale_security_group_rules" in state["module.cluster.module.lb"]:
+        terraform_state_rm(
+            "module.cluster.module.lb.exoscale_security_group_rules.load_balancers",
+            log=True,
+        )
+        migrate_security_group_rules_lb(state)
+
+    # Affinity groups
+    migrate_simple_resource(
+        state,
+        "module.cluster.module.lb",
+        "exoscale_affinity",
+        "exoscale_anti_affinity_group",
+        "lb",
+        index=-1,
+    )
+    for group in default_node_groups:
+        migrate_simple_resource(
+            state,
+            f"module.cluster.module.{group}",
+            "exoscale_affinity",
+            "exoscale_anti_affinity_group",
+            "anti_affinity_group",
+        )
+    for group in additional_worker_groups:
+        migrate_simple_resource(
+            state,
+            f'module.cluster.module.additional_worker["{group}"]',
+            "exoscale_affinity",
+            "exoscale_anti_affinity_group",
+            "anti_affinity_group",
+        )
+
+    # LB network
+    # migrate network
+    migrate_simple_resource(
+        state,
+        "module.cluster.module.lb",
+        "exoscale_network",
+        "exoscale_private_network",
+        "lbnet",
+        zone=zone,
+    )
+    # remove no longer used `exoscale_nic` resources
+    if "exoscale_nic" in state["module.cluster.module.lb"]:
+        terraform_state_rm("module.cluster.module.lb.exoscale_nic.lb", log=True)
+        if "additional_network" in state["module.cluster.module.lb"]["exoscale_nic"]:
+            terraform_state_rm(
+                "module.cluster.module.lb.exoscale_nic.additional_network",
+                log=True,
+            )
+
+    # Compute
+    # LBs
+    for i in range(2):
+        migrate_simple_resource(
+            state,
+            "module.cluster.module.lb",
+            "exoscale_compute",
+            "exoscale_compute_instance",
+            "lb",
+            index=i,
+            zone=zone,
+        )
+    for group in default_node_groups:
+        modname = f"module.cluster.module.{group}"
+        for i in range(read_node_count(state, modname)):
+            migrate_simple_resource(
+                state,
+                modname,
+                "exoscale_compute",
+                "exoscale_compute_instance",
+                "nodes",
+                index=i,
+                zone=zone,
+            )
+
+    for group in additional_worker_groups:
+        modname = f'module.cluster.module.additional_worker["{group}"]'
+        for i in range(read_node_count(state, modname)):
+            migrate_simple_resource(
+                state,
+                modname,
+                "exoscale_compute",
+                "exoscale_compute_instance",
+                "nodes",
+                index=i,
+                zone=zone,
+            )
+
+
+if __name__ == "__main__":
+    state_json_name = None
+    if len(sys.argv) >= 2:
+        state_json_name = sys.argv[1]
+        dry_run = True
+    main(state_json_name)

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/migrate-state-v2-v3.sh
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/migrate-state-v2-v3.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+terraform state mv module.cluster.cloudscale_floating_ip.api_vip module.cluster.module.lb.cloudscale_floating_ip.api_vip
+terraform state mv module.cluster.cloudscale_floating_ip.router_vip module.cluster.module.lb.cloudscale_floating_ip.router_vip
+terraform state mv module.cluster.cloudscale_floating_ip.nat_vip module.cluster.module.lb.cloudscale_floating_ip.nat_vip
+
+terraform state mv module.cluster.cloudscale_server.lb module.cluster.module.lb.cloudscale_server.lb
+terraform state mv module.cluster.cloudscale_server_group.lb module.cluster.module.lb.cloudscale_server_group.lb
+terraform state mv module.cluster.random_id.lb module.cluster.module.lb.random_id.lb
+terraform state mv module.cluster.null_resource.register_lb module.cluster.module.lb.null_resource.register_lb
+
+terraform state mv module.cluster.data.local_file.hieradata_mr_url 'module.cluster.module.lb.module.hiera.data.local_file.hieradata_mr_url[0]'
+terraform state mv 'module.cluster.gitfile_checkout.appuio_hieradata[0]' module.cluster.module.lb.module.hiera.gitfile_checkout.appuio_hieradata
+terraform state mv 'module.cluster.local_file.lb_hieradata[0]' module.cluster.module.lb.module.hiera.local_file.lb_hieradata
+
+terraform state mv module.cluster.cloudscale_network.privnet 'module.cluster.cloudscale_network.privnet[0]'
+terraform state mv module.cluster.cloudscale_subnet.privnet_subnet 'module.cluster.cloudscale_subnet.privnet_subnet[0]'

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/outputs.tf.json
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/outputs.tf.json
@@ -1,0 +1,7 @@
+{
+  "output": {
+    "cluster_dns": {
+      "value": "${module.cluster.ns_records}"
+    }
+  }
+}

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/terraform.sh
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/terraform.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Intended to run as root, this script ensures that the non-privileged user
+# that we want to run as in the end can use git-https and curl.
+# TODO: build custom Terraform CI image based on GitLab's image.
+adduser -D -s /bin/sh -u "${REAL_UID}" -h /tf terraform
+apk add --no-cache curl >/dev/null 2>&1
+export GIT_ASKPASS=/tf/git-askpass.sh
+# Note: busybox `su` can't directly execute a binary, so we use the secondary
+# script which only does `exec terraform`.
+su -p terraform /tf/tf.sh -- "$@"

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/tf.sh
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/tf.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec terraform "$@"

--- a/tests/golden/stackit/openshift4-terraform/openshift4-terraform/variables.tf.json
+++ b/tests/golden/stackit/openshift4-terraform/openshift4-terraform/variables.tf.json
@@ -1,0 +1,7 @@
+{
+  "variable": {
+    "ignition_bootstrap": {
+      "default": ""
+    }
+  }
+}

--- a/tests/stackit.yml
+++ b/tests/stackit.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/stackit.yml
+++ b/tests/stackit.yml
@@ -1,3 +1,12 @@
-# Overwrite parameters here
-
-# parameters: {...}
+parameters:
+  # Provide fake facts for Exoscale/CH-DK-2
+  facts:
+    cloud: stackit
+    region: eu01
+  openshift4_terraform:
+    terraform_variables:
+      base_domain: stackit.ch
+      ignition_ca: SomeCertificateString
+      ssh_key: ssh-ed25519 AA...
+      image_id: some-image-uuid
+      stackit_project_id: some-project-uuid


### PR DESCRIPTION
Open question: What is the deal with gitlab CI? Is that in use anywhere? I wasn't aware that any of our clusters are automatically terraformed.

In its current state, terraforming stackit via CI is not straightforward, as they don't provide long-lived tokens that can be used by Terraform. It can be set up with a CI variable, but we'd have to manually rotate the token every so often.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
